### PR TITLE
Don't give any player access by default.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+end_of_line = crlf
+insert_final_newline = true
+charset = utf-8
+indent_style = tab
+tab_width = 4
+trim_trailing_whitespace = true
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[pom.xml]
+indent_style = space
+intent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# IDEs #
+.idea
+*.iml
+.settings
+.externalToolBuilders
+.classpath
+.project
+.metadata
+
+# Generated #
+obj
+target
+build
+bin
+javadoc
+site
+dependency-reduced-pom.xml
+maven-eclipse.xml
+*.class
+git.properties
+
+# Files #
+*.bat

--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -31,55 +31,55 @@ permissions:
         asedit.placement: true
     asedit.basic:
       desciption: Allow use armorstand edit functions. If set to false it will override all other functions.
-      default: true
+      default: op
     asedit.copy:
       description: Allows use of the copy/paste settings fuction.
-      default: true
+      default: op
     asedit.showarms:
       description: Toggle arms on/off.
-      default: true
+      default: op
     asedit.invisible:
       description: Toggle armorstand visible/invisible.
-      default: true
+      default: op
     asedit.size:
       description: Toggle armorstand size normal/small.
-      default: true
+      default: op
     asedit.baseplate:
       description: Toggle baseplate visible/invisible.
-      default: true
+      default: op
     asedit.gravity: 
       description: Toggle falling/floating armorstand.
-      default: true
+      default: op
     asedit.placement:
       description: Adjust armorstand's location.
-      default: true
+      default: op
     asedit.head:
       description: Adjust head position.
-      default: true
+      default: op
     asedit.body:
       description: Adjust body position.
-      default: true
+      default: op
     asedit.positionarms:
       description: Adjust arm position.
-      default: true
+      default: op
       children:
       asedit.leftarm: true
       asedit.rightarm: true
     asedit.positionlegs:
       description: Adjust leg position.
-      default: true
+      default: op
       children:
       asedit.leftleg: true
       asedit.rightleg: true
     asedit.leftarm:
       description: Adjust left arm position
-      default: true
+      default: op
     asedit.rightarm:
       description: Adjust right arm position
-      default: true
+      default: op
     asedit.leftleg: 
       description: Adjust left leg position
-      default: true
+      default: op
     asedit.rightleg:
       description: Adjust right leg position
-      default: true
+      default: op

--- a/src/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -118,6 +118,9 @@ public class PlayerEditorManager implements Listener{
 
 	@EventHandler (priority = EventPriority.NORMAL, ignoreCancelled=false)
 	void onRightClickTool(PlayerInteractEvent e){
+		if (!e.getPlayer().hasPermission("asedit.basic")) {
+			return;
+		}
 		try {
 			if(e.getAction() == Action.LEFT_CLICK_AIR 
 					|| e.getAction() == Action.RIGHT_CLICK_AIR


### PR DESCRIPTION
This caused issues with the children permissions as we could not deny the permissions properly.

Also its unlogical if you give every permission `default: true` and the all permission `default:op`

Alos adds a permisison check for the inventory opening.
