### PR TITLE
French translation update

### DIFF
--- a/resources/lang/fr_FR.yml
+++ b/resources/lang/fr_FR.yml
@@ -49,9 +49,9 @@ copied:
 pasted: 
   msg: État du valet collé depuis l'emplacement <x>.
 target:
-  msg: Cible du valet verrouillée.
+  msg: Valet cible verrouillé.
 notarget:
-  msg: Cible du valet déverrouillée.
+  msg: Valet cible déverrouillé.
 
 #warn
 cantedit:

--- a/resources/lang/fr_FR.yml
+++ b/resources/lang/fr_FR.yml
@@ -24,7 +24,6 @@ setmode:
   baseplate: Affichage ou retrait de la plaque de base
   placement: Position
   rotate: Rotation
-  target: Cible
   copy: Copie
   paste: Collage
   reset: Réinitialisation de la pose
@@ -49,6 +48,10 @@ copied:
   msg: État du valet copié dans l'emplacement <x>.
 pasted: 
   msg: État du valet collé depuis l'emplacement <x>.
+target:
+  msg: Cible du valet verrouillée.
+notarget:
+  msg: Cible du valet déverrouillée.
 
 #warn
 cantedit:
@@ -148,10 +151,6 @@ rotate:
   msg: Rotation
   description:
     msg: Fait tourner l'ensemble du valet sur lui-même
-target: 
-  msg: Cible
-  description:
-    msg: Prochainement !
 copy: 
   msg: Copie
   description:


### PR DESCRIPTION
Updated French translation for 6e28c817e60abb7b35d2ea90e90a7828dd3d149b.

Cf. [this comment](https://github.com/RypoFalem/ArmorStandEditor/commit/6e28c817e60abb7b35d2ea90e90a7828dd3d149b#commitcomment-19979806) before merge, as I assumed this was an error and removed the keys in this update. I can be wrong.

If you consider adding new translations in the near future, keep this PR open and I will translate new strings as you implement them :) .
Else, I'll reopen update pull requests when (or before if you ping) you release new features.