### PR TITLE
Return original items to menu + plugin is no longer abandoned?

### DIFF
--- a/src/main/java/io/github/rypofalem/armorstandeditor/menu/Menu.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/menu/Menu.java
@@ -170,7 +170,7 @@ public class Menu {
 			paste = createIcon(new ItemStack(Material.ENCHANTED_BOOK),
 					"paste","mode paste");
 
-			slot1 = createIcon(new ItemStack(Material.DANDELION_YELLOW),
+			slot1 = createIcon(new ItemStack(Material.DANDELION),
 					"copyslot","slot 1", "1");
 
 			slot2 = createIcon(new ItemStack(Material.AZURE_BLUET, 2),
@@ -179,7 +179,7 @@ public class Menu {
 			slot3 = createIcon(new ItemStack(Material.BLUE_ORCHID, 3),
 					"copyslot","slot 3", "3");
 
-			slot4 = createIcon( new ItemStack(Material.LILAC, 4),
+			slot4 = createIcon( new ItemStack(Material.PEONY, 4),
 					"copyslot","slot 4", "4");
 		}
 


### PR DESCRIPTION
As you stated on plugin page, `I am no longer offering support or updates to this plugin. The resources will remain here for those that would like to use them.` So does this update means that plugin is no longer abandoned? There was several forks, so can we now merge them (or, at least mine) to add new features to plugin?

Also, there's differences between menu in 1.12 and 1.13, this commit fixes it.