### PR TITLE
fix for lectern destroy event

### DIFF
--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -271,6 +271,9 @@ public class PlayerEditorManager implements Listener{
 
 	@EventHandler (priority = EventPriority.MONITOR, ignoreCancelled=true)
 	void onPlayerMenuClose(InventoryCloseEvent e){
+		// spigot bug: this event is called when detroying a lectern that you just opened and closed
+		// Unfortunately, Inventory.getHolder() of a destroyed Lectern is not a Lectern and it errors out
+		if(e.getInventory().getClass().getName().equals("CraftInventoryLectern")) return;
 		if(e.getInventory().getHolder() == null) return;
 		if(!(e.getInventory().getHolder() instanceof ASEHolder)) return;
 		if(e.getInventory().getHolder() == equipmentHolder){


### PR DESCRIPTION
Fixes false lectern close event errors:

```
[13:30:50 ERROR]: Could not pass event InventoryCloseEvent to ArmorStandEditor v1.13-21
java.lang.ClassCastException: org.bukkit.craftbukkit.v1_14_R1.block.CraftBlockState cannot be cast to org.bukkit.block.Lectern
        at net.minecraft.server.v1_14_R1.TileEntityLectern$LecternInventory.getOwner(TileEntityLectern.java:57) ~[patched_1.14.2.jar:git-Paper-70]
        at org.bukkit.craftbukkit.v1_14_R1.inventory.CraftInventoryLectern.getHolder(CraftInventoryLectern.java:15) ~[patched_1.14.2.jar:git-Paper-70]
        at org.bukkit.craftbukkit.v1_14_R1.inventory.CraftInventoryLectern.getHolder(CraftInventoryLectern.java:7) ~[patched_1.14.2.jar:git-Paper-70]
        at io.github.rypofalem.armorstandeditor.PlayerEditorManager.onPlayerMenuClose(PlayerEditorManager.java:276) ~[?:?]
        at com.destroystokyo.paper.event.executor.MethodHandleEventExecutor.execute(MethodHandleEventExecutor.java:37) ~[patched_1.14.2.jar:git-Paper-70]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[patched_1.14.2.jar:git-Paper-70]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[patched_1.14.2.jar:git-Paper-70]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:536) ~[patched_1.14.2.jar:git-Paper-70]
        at org.bukkit.craftbukkit.v1_14_R1.event.CraftEventFactory.handleInventoryCloseEvent(CraftEventFactory.java:1332) ~[patched_1.14.2.jar:git-Paper-70]
        at net.minecraft.server.v1_14_R1.EntityPlayer.closeInventory(EntityPlayer.java:1247) ~[patched_1.14.2.jar:git-Paper-70]
        at net.minecraft.server.v1_14_R1.EntityPlayer.tick(EntityPlayer.java:368) ~[patched_1.14.2.jar:git-Paper-70]
        at net.minecraft.server.v1_14_R1.WorldServer.entityJoinedWorld(WorldServer.java:579) ~[patched_1.14.2.jar:git-Paper-70]
        at net.minecraft.server.v1_14_R1.World.a(World.java:895) ~[patched_1.14.2.jar:git-Paper-70]
        at net.minecraft.server.v1_14_R1.WorldServer.doTick(WorldServer.java:354) ~[patched_1.14.2.jar:git-Paper-70]
        at net.minecraft.server.v1_14_R1.MinecraftServer.b(MinecraftServer.java:1177) ~[patched_1.14.2.jar:git-Paper-70]
        at net.minecraft.server.v1_14_R1.DedicatedServer.b(DedicatedServer.java:418) ~[patched_1.14.2.jar:git-Paper-70]
        at net.minecraft.server.v1_14_R1.MinecraftServer.a(MinecraftServer.java:1060) ~[patched_1.14.2.jar:git-Paper-70]
        at net.minecraft.server.v1_14_R1.MinecraftServer.run(MinecraftServer.java:904) ~[patched_1.14.2.jar:git-Paper-70]
```