### PR TITLE
Fix permission nodes which should have children

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -51,14 +51,14 @@ permissions:
       description: Adjust arm position.
       default: true
       children:
-      asedit.leftarm: true
-      asedit.rightarm: true
+        asedit.leftarm: true
+        asedit.rightarm: true
     asedit.positionlegs:
       description: Adjust leg position.
       default: true
       children:
-      asedit.leftleg: true
-      asedit.rightleg: true
+        asedit.leftleg: true
+        asedit.rightleg: true
     asedit.leftarm:
       description: Adjust left arm position
       default: true


### PR DESCRIPTION
Due to incorrect indentation, these permission nodes didn't have children permission nodes. For example:
```json
yq '.permissions."asedit.positionlegs"' plugin.yml
{
  "description": "Adjust leg position.",
  "default": true,
  "children": null,
  "asedit.leftleg": true,
  "asedit.rightleg": true
}
```