### PR TITLE
Don't cancel the interact event

### DIFF
--- a/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/PlayerEditorManager.java
@@ -215,6 +215,7 @@ public class PlayerEditorManager implements Listener{
 				|| e.getAction() == Action.RIGHT_CLICK_BLOCK)) return;
 		Player player = e.getPlayer();
 		if(!plugin.isEditTool(player.getInventory().getItemInMainHand())) return;
+		if(!player.hasPermission("asedit.basic")) return;
 		e.setCancelled(true);
 		getPlayerEditor(player.getUniqueId()).openMenu();
 	}


### PR DESCRIPTION
If the player doesn't have permission to use the basic functionality of the plugin, don't cancel the interact event.
Fixes #30